### PR TITLE
Add http:// to the link for Julia

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/sawcordwell/MDPs.jl.svg?branch=master)](https://travis-ci.org/sawcordwell/MDPs.jl)
 [![Coverage Status](https://coveralls.io/repos/sawcordwell/MDPs.jl/badge.png?branch=master)](https://coveralls.io/r/sawcordwell/MDPs.jl?branch=master)
 
-*MDPs* is a [Julia](www.julialang.org) package for working with Markov
+*MDPs* is a [Julia](http://www.julialang.org/) package for working with Markov
 decision processes (MDPs).
 
 ## Installation


### PR DESCRIPTION
Without `http://`, the link is relative, which links to a 404 page on github.
