### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-  - release
+  - 0.3
   - nightly
 script:
   - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("MDPs", coverage=true)'


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this
package supports julia 0.3 so it should continue to be tested